### PR TITLE
Bump ember-cli-babel dependency to v6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.3.0",
+    "ember-cli-babel": "^6.6.0",
     "eslint-plugin-ember-suave": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes https://github.com/buschtoens/ember-route-task-helper/issues/16